### PR TITLE
Update tasks to make instance's command 'decidim:upgrade'  fetch module's migrations

### DIFF
--- a/lib/tasks/decidim_superspaces_upgrade_tasks.rake
+++ b/lib/tasks/decidim_superspaces_upgrade_tasks.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rake::Task["decidim:choose_target_plugins"].enhance do
-  ENV["FROM"] = "#{ENV.fetch("FROM", nil)},decidim_superpaces" unless ENV["FROM"].to_s.include?("decidim_superpaces")
+  ENV["FROM"] = "#{ENV.fetch("FROM", nil)},decidim_superspaces" unless ENV["FROM"].to_s.include?("decidim_superspaces")
 end

--- a/lib/tasks/decidim_superspaces_upgrade_tasks.rake
+++ b/lib/tasks/decidim_superspaces_upgrade_tasks.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rake::Task["decidim:choose_target_plugins"].enhance do
-  ENV["FROM"] = "#{ENV.fetch("FROM", nil)},decidim_superpace" unless ENV["FROM"].to_s.include?("decidim_superpace")
+  ENV["FROM"] = "#{ENV.fetch("FROM", nil)},decidim_superpaces" unless ENV["FROM"].to_s.include?("decidim_superpaces")
 end

--- a/lib/tasks/decidim_superspaces_upgrade_tasks.rake
+++ b/lib/tasks/decidim_superspaces_upgrade_tasks.rake
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rake::Task["decidim:choose_target_plugins"].enhance do
+  ENV["FROM"] = "#{ENV.fetch("FROM", nil)},decidim_superpace" unless ENV["FROM"].to_s.include?("decidim_superpace")
+end


### PR DESCRIPTION
When we introduce a new migration on Superspaces module, and we update an instance to use the most recent version of the module, we sometimes forget to execute the 'install migrations' command. 

This change automates this action by letting decidim command 'bin/rails decidim:upgrade' install the latest migrations of the module. 